### PR TITLE
fixing gallery links

### DIFF
--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -1051,7 +1051,7 @@ public class ModularParser implements MediaWikiParser,
 					for (String s : tokenize(sm, startSpan.getEnd(), endSpan
 							.getStart(), lineSeparator))
 					{
-						sb.append("[[" + s + "]]" + lineSeparator);
+					        sb.append("[[" + imageIdentifers.get(0) + ":" + s + "]]" + lineSeparator);
 					}
 
 					// replace the source and remove the tags

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
@@ -1,0 +1,39 @@
+package de.tudarmstadt.ukp.wikipedia.parser;
+
+import de.tudarmstadt.ukp.wikipedia.api.WikiConstants;
+import de.tudarmstadt.ukp.wikipedia.parser.mediawiki.MediaWikiParser;
+import de.tudarmstadt.ukp.wikipedia.parser.mediawiki.MediaWikiParserFactory;
+import org.junit.Test;
+
+/**
+ * Created by dav009 on 23/06/2015.
+ */
+public class ParserTest {
+
+    @Test
+    public void testGalleryLinks(){
+        String title = "Wikipedia API";
+
+        String LF = "\n";
+        String text = "India collided with Asia {{Ma|55|45}} creating the Himalayas; Arabia collided with Eurasia, " +
+                "closing the [[Tethys ocean]] and creating the Zagros Mountains, " +
+                "around {{Ma|35}}.<ref name=Allen2008>{{cite doi|10.1016/j.palaeo.2008.04.021 }}</ref>\n" +
+                "<gallery>\n" +
+                "|35  million years ago\n" +
+                "|20  million years ago\n" +
+                "</gallery>";
+
+        MediaWikiParserFactory pf = new MediaWikiParserFactory(WikiConstants.Language.english);
+        MediaWikiParser parser = pf.createParser();
+
+        ParsedPage pp = parser.parse(text);
+
+        for (Section s : pp.getSections()){
+            for (Link link : s.getLinks()) {
+                assert(!link.getTarget().equals(""));
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
So this is a dependency of jsonpedia.
At some point it looks for the gallery tags in a wikiarticle and try to handle the links there as images.

There is a bug in the function handling the galleries as it expects the galleries to come as: `ImageKeyWord:image.jpg`, none of all them come with that keyword and then they are assumed to be regular links which points to empty wikiIDs.

This fix adds the right keyword, so they are handled as images. This means that they won't show up on the links section on jsonpedia
