### PR TITLE
Feature/dp fixing image gallery links

### DIFF
--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/Link.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/Link.java
@@ -123,4 +123,13 @@ public class Link extends ParsedPageObject{
 		}
 		return result.toString();
 	}
+
+    public boolean equals(Link l){
+        if ( l.getPos().getStart() == this.getPos().getStart() &&
+             l.getPos().getEnd() == this.getPos().getEnd() &&
+             l.getText().equals(this.getText()) &&
+             l.getTarget().equals(this.getTarget()))
+            return true;
+        return false;
+    }
 }

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -1047,21 +1047,27 @@ public class ModularParser implements MediaWikiParser,
 						}
 					}
 
-					// images
+					// Images sometimes carry a paragraph with them. Those paragraphs can contain wikipedia links
+					// as well as usual media-wiki format content.
+                    // This piece of code separates the paragraph
+                    // so that the rest of the pipeline can process it and extract relevant information from it
+                    // please refer to : https://en.wikipedia.org/wiki/Help:Gallery_tag
 					for (String imageParagraph : tokenize(sm, startSpan.getEnd(), endSpan
 							.getStart(), lineSeparator))
 					{
                           String[] splitImageParagraph = imageParagraph.split("\\|");
                           String imageLink = "";
                           if(splitImageParagraph.length == 1){
+                              // Figures without a paragraph
                               imageParagraph = "";
                               imageLink = splitImageParagraph[0];
                           } else{
+                              // Figures with a paragraph
                               imageParagraph = imageParagraph.replace(splitImageParagraph[0] + "|", "");
                               imageLink = splitImageParagraph[0];
                           }
 
-                          sb.append("[[" + imageIdentifers.get(0) + ":"+imageLink +"]]" + imageParagraph + lineSeparator);
+                          sb.append("[[" + imageIdentifers.get(0) + ":" + imageLink + "]]" + imageParagraph + lineSeparator);
 					}
 
 					// replace the source and remove the tags

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -1047,40 +1047,39 @@ public class ModularParser implements MediaWikiParser,
 						}
 					}
 
-					// Images sometimes carry a paragraph with them. Those paragraphs can contain wikipedia links
-					// as well as usual media-wiki format content.
+                    // Images sometimes carry a paragraph with them. Those paragraphs can contain wikipedia links
+                    // as well as usual media-wiki format content.
                     // This piece of code separates the paragraph
                     // so that the rest of the pipeline can process it and extract relevant information from it
                     // please refer to : https://en.wikipedia.org/wiki/Help:Gallery_tag
-					for (String imageParagraph : tokenize(sm, startSpan.getEnd(), endSpan
-							.getStart(), lineSeparator))
-					{
-                          String[] splitImageParagraph = imageParagraph.split("\\|");
-                          String imageLink = "";
-                          if(splitImageParagraph.length == 1){
-                              // Figures without a paragraph
-                              imageParagraph = "";
-                              imageLink = splitImageParagraph[0];
-                          } else{
-                              // Figures with a paragraph
-                              imageParagraph = imageParagraph.replace(splitImageParagraph[0] + "|", "");
-                              imageLink = splitImageParagraph[0];
-                          }
+                    for (String imageParagraph : tokenize(sm, startSpan.getEnd(), endSpan
+                        .getStart(), lineSeparator))
+                    {
+                        String[] splitImageParagraph = imageParagraph.split("\\|");
+                        String imageLink = "";
+                        if(splitImageParagraph.length == 1){
+                             // Figures without a paragraph
+                            imageParagraph = "";
+                            imageLink = splitImageParagraph[0];
+                        } else{
+                            // Figures with a paragraph
+                            imageParagraph = imageParagraph.replace(splitImageParagraph[0] + "|", "");
+                            imageLink = splitImageParagraph[0];
+                        }
+                        sb.append("[[" + imageIdentifers.get(0) + ":" + imageLink + "]]" + imageParagraph + lineSeparator);
+                    }
 
-                          sb.append("[[" + imageIdentifers.get(0) + ":" + imageLink + "]]" + imageParagraph + lineSeparator);
-					}
-
-					// replace the source and remove the tags
-					sm.replace(startSpan.getStart(), endSpan.getEnd(), sb
-							.toString());
-				}
-				else
-				{
-					continue;
-				}
-			}
-		}
-	}
+                    // replace the source and remove the tags
+                    sm.replace(startSpan.getStart(), endSpan.getEnd(), sb
+                        .toString());
+                }
+                else
+                {
+                    continue;
+                }
+            }
+        }
+    }
 
 	private Table buildTable(SpanManager sm,
 			ContentElementParsingParameters cepp, LinkedList<Span> lineSpans)

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -1048,10 +1048,20 @@ public class ModularParser implements MediaWikiParser,
 					}
 
 					// images
-					for (String s : tokenize(sm, startSpan.getEnd(), endSpan
+					for (String imageParagraph : tokenize(sm, startSpan.getEnd(), endSpan
 							.getStart(), lineSeparator))
 					{
-					        sb.append("[[" + imageIdentifers.get(0) + ":" + s + "]]" + lineSeparator);
+                          String[] splitImageParagraph = imageParagraph.split("\\|");
+                          String imageLink = "";
+                          if(splitImageParagraph.length == 1){
+                              imageParagraph = "";
+                              imageLink = splitImageParagraph[0];
+                          } else{
+                              imageParagraph = imageParagraph.replace(splitImageParagraph[0] + "|", "");
+                              imageLink = splitImageParagraph[0];
+                          }
+
+                          sb.append("[[" + imageIdentifers.get(0) + ":"+imageLink +"]]" + imageParagraph + lineSeparator);
 					}
 
 					// replace the source and remove the tags

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
@@ -36,4 +36,42 @@ public class ParserTest {
 
 
     }
+
+
+    @Test
+    public void testExtractingLinksFromGallery(){
+
+        String text = "==History==\n" +
+                "<gallery>\n" +
+                "Image:Buckingham Branch Railroad GP16 rebuild.JPG|BB 2, a [[GP16]], getting a new coat of paint at [[Dillwyn, Virginia]].\n" +
+                "Image:BBRR4 Dillwyn WJGrimes.JPG|BBRR 4, an [[RS-4-TC]], with a new coat of paint at [[Dillwyn, Virginia]].\n" +
+                "Image:BB7 Louisa WJGrimes.JPG|BB 7, a [[GP40]], heading east at [[Louisa, Virginia]].\n" +
+                "Image:BBRR8 Doswell WJGrimes.JPG|BB 8, a GP16 in GRIV paint at [[Doswell, Virginia]].\n" +
+                "Image:Bb 13 augusta co-op.jpg|BB 13 switches Augusta CO-OP in [[Staunton, Virginia]].\n" +
+                "Image:Bb_7_svrr_staunton,_va_08292010.jpg|BB 7 with sisters, south on the [[Shenandoah Valley Railroad (short-line)|Shenandoah Valley Railroad]] in [[Staunton, Virginia]]. Having just made a pick up of Empty Cars to take West.\n" +
+                "Image:image_with_no_par.jpg\n" +
+                "</gallery>";
+
+        MediaWikiParserFactory pf = new MediaWikiParserFactory(WikiConstants.Language.english);
+        MediaWikiParser parser = pf.createParser();
+
+        ParsedPage pp = parser.parse(text);
+
+        for (Section s : pp.getSections()){
+            for (Paragraph p: s.getParagraphs()){
+                System.out.println(p.getText());
+                for (Link link : p.getLinks()) {
+                    System.out.println("\t"+link.getPos().getStart());
+                    System.out.println("\t"+link.getPos().getEnd());
+                    System.out.println("\t"+link.getText());
+                    if (link.getPos().getStart()!=link.getPos().getEnd())
+                     System.out.println("\t"+link.getText().substring(link.getPos().getStart(),link.getPos().getEnd())) ;
+                }
+            }
+        }
+
+
+
+
+    }
 }

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
@@ -73,7 +73,14 @@ public class ParserTest {
         assert(this.findLinkInList(new Link(testPar, new Span(45, 62), "Dillwyn,_Virginia",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
         assert(this.findLinkInList(new Link(testPar, new Span(312, 338), "Shenandoah_Valley_Railroad_(short-line)",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
         assert(this.findLinkInList(new Link(testPar, new Span(428, 437), "Spiderman",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
-        assert(testPar.getText().substring(45, 62).equals("Dillwyn, Virginia"));
+
+        for (Link l: testPar.getLinks()){
+            int start = l.getPos().getStart();
+            int end = l.getPos().getEnd();
+            if(start!=end){
+                assert(testPar.getText().substring(start, end).equals(l.getText()));
+            }
+        }
         assert(testPar.getText().contains("a GP16, getting a new coat of paint at "));
 
     }

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
@@ -5,6 +5,9 @@ import de.tudarmstadt.ukp.wikipedia.parser.mediawiki.MediaWikiParser;
 import de.tudarmstadt.ukp.wikipedia.parser.mediawiki.MediaWikiParserFactory;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 /**
  * Created by dav009 on 23/06/2015.
  */
@@ -37,6 +40,13 @@ public class ParserTest {
 
     }
 
+    public boolean findLinkInList(Link l, Collection<Link> list){
+         for(Link currentLink:list){
+             if (l.equals(currentLink)) return true;
+         }
+        return false;
+    }
+
 
     @Test
     public void testExtractingLinksFromGallery(){
@@ -50,28 +60,21 @@ public class ParserTest {
                 "Image:Bb 13 augusta co-op.jpg|BB 13 switches Augusta CO-OP in [[Staunton, Virginia]].\n" +
                 "Image:Bb_7_svrr_staunton,_va_08292010.jpg|BB 7 with sisters, south on the [[Shenandoah Valley Railroad (short-line)|Shenandoah Valley Railroad]] in [[Staunton, Virginia]]. Having just made a pick up of Empty Cars to take West.\n" +
                 "Image:image_with_no_par.jpg\n" +
+                "Image:image_with_par.jpg|Something [[Spiderman]]\n" +
                 "</gallery>";
 
         MediaWikiParserFactory pf = new MediaWikiParserFactory(WikiConstants.Language.english);
         MediaWikiParser parser = pf.createParser();
-
         ParsedPage pp = parser.parse(text);
+        Paragraph testPar;
+        testPar = pp.getSections().get(0).getParagraphs().get(0);
 
-        for (Section s : pp.getSections()){
-            for (Paragraph p: s.getParagraphs()){
-                System.out.println(p.getText());
-                for (Link link : p.getLinks()) {
-                    System.out.println("\t"+link.getPos().getStart());
-                    System.out.println("\t"+link.getPos().getEnd());
-                    System.out.println("\t"+link.getText());
-                    if (link.getPos().getStart()!=link.getPos().getEnd())
-                     System.out.println("\t"+link.getText().substring(link.getPos().getStart(),link.getPos().getEnd())) ;
-                }
-            }
-        }
-
-
-
+        assert(this.findLinkInList(new Link(testPar, new Span(8, 12), "GP16",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
+        assert(this.findLinkInList(new Link(testPar, new Span(45, 62), "Dillwyn,_Virginia",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
+        assert(this.findLinkInList(new Link(testPar, new Span(312, 338), "Shenandoah_Valley_Railroad_(short-line)",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
+        assert(this.findLinkInList(new Link(testPar, new Span(428, 437), "Spiderman",  Link.type.INTERNAL, new ArrayList<String>()), testPar.getLinks()));
+        assert(testPar.getText().substring(45, 62).equals("Dillwyn, Virginia"));
+        assert(testPar.getText().contains("a GP16, getting a new coat of paint at "));
 
     }
 }


### PR DESCRIPTION
Figures in Galleries come with Paragraphs (i.e: train gallery here: https://en.wikipedia.org/?title=Buckingham_Branch_Railroad )
Currently we get the links from those paragraphs but we don't get the text/paragraphs correctly.

This PR gets the paragraphs from those figures, and slightly change the format such that those paragraphs are processed correctly by the rest of the pipeline.
