### PR TITLE
Fixing - Annotations with colons

### DIFF
--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -11,10 +11,7 @@
 package de.tudarmstadt.ukp.wikipedia.parser.mediawiki;
 
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Stack;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,6 +31,21 @@ import de.tudarmstadt.ukp.wikipedia.parser.Content.FormatType;
 public class ModularParser implements MediaWikiParser,
 		MediaWikiContentElementParser
 {
+
+	//Link has namespace but is not image
+	String[] namespaces = {"image", "talk", "user", "project", "file", "project_talk", "mediaWiki",
+			"mediaWiki_talk", "template", "template_talk", "help", "help_talk",
+			"category", "category_talk", "thread", "thread_talk", "summary",
+			"summary_talk", "relation", "relation_talk", "property",
+			"property_talk", "type", "type_talk", "form", "form_talk", "concept",
+			"concept_talk", "forum", "forum_talk", "cite", "cite_talk", "relation",
+			"media", "Special", "UserWiki", "userWiki_talk", "user_profile",
+			"user_profile_talk", "page", "page_talk", "index", "index_talk",
+			"widget", "widget_talk", "jSApplet", "jSApplet_talk", "poll", "poll_talk",
+			"imageAnnotation", "layer", "layer_talk", "quiz", "quiz_talk", "translations",
+			"translations_talk", "module", "module_talk", "imageidentifers"};
+
+	Set<String> allNamespaces = new HashSet<String>(java.util.Arrays.asList(namespaces));
 
 	private final Log logger = LogFactory.getLog(getClass());
 
@@ -1604,8 +1616,11 @@ public class ModularParser implements MediaWikiParser,
 				}
 				else
 				{
-					//Link has namespace but is not image
-					linkType = Link.type.UNKNOWN;
+					if (allNamespaces.contains(namespace.toLowerCase())) {
+						linkType = Link.type.UNKNOWN;
+				    }else{
+						linkType = Link.type.INTERNAL;
+					}
 					parameters = null;
 				}
 			}

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -1623,9 +1623,12 @@ public class ModularParser implements MediaWikiParser,
 				}
 				else
 				{
-					if (allNamespaces.contains(namespace.toLowerCase())) {
+					if (allNamespaces.contains(namespace.toLowerCase()))
+					{
 						linkType = Link.type.UNKNOWN;
-					}else{
+					}
+					else
+					{
 						linkType = Link.type.INTERNAL;
 					}
 					parameters = null;

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -43,7 +43,9 @@ public class ModularParser implements MediaWikiParser,
 			"user_profile_talk", "page", "page_talk", "index", "index_talk",
 			"widget", "widget_talk", "jSApplet", "jSApplet_talk", "poll", "poll_talk",
 			"imageAnnotation", "layer", "layer_talk", "quiz", "quiz_talk", "translations",
-			"translations_talk", "module", "module_talk", "imageidentifers"};
+			"translations_talk", "module", "module_talk", "imageidentifers", "wikipedia",
+	        "meta", "additional", "portal", "project", "userbox", "userbox_talk", "interpretation",
+	        "interpretation_talk"};
 
 	Set<String> allNamespaces = new HashSet<String>(java.util.Arrays.asList(namespaces));
 

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/mediawiki/ModularParser.java
@@ -11,7 +11,12 @@
 package de.tudarmstadt.ukp.wikipedia.parser.mediawiki;
 
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Stack;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -39,10 +44,10 @@ public class ModularParser implements MediaWikiParser,
 			"summary_talk", "relation", "relation_talk", "property",
 			"property_talk", "type", "type_talk", "form", "form_talk", "concept",
 			"concept_talk", "forum", "forum_talk", "cite", "cite_talk", "relation",
-			"media", "Special", "UserWiki", "userWiki_talk", "user_profile",
+			"media", "special", "userwiki", "userwiki_talk", "user_profile",
 			"user_profile_talk", "page", "page_talk", "index", "index_talk",
-			"widget", "widget_talk", "jSApplet", "jSApplet_talk", "poll", "poll_talk",
-			"imageAnnotation", "layer", "layer_talk", "quiz", "quiz_talk", "translations",
+			"widget", "widget_talk", "jsapplet", "jsapplet_talk", "poll", "poll_talk",
+			"imageannotation", "layer", "layer_talk", "quiz", "quiz_talk", "translations",
 			"translations_talk", "module", "module_talk", "imageidentifers", "wikipedia",
 	        "meta", "additional", "portal", "project", "userbox", "userbox_talk", "interpretation",
 	        "interpretation_talk"};
@@ -1620,7 +1625,7 @@ public class ModularParser implements MediaWikiParser,
 				{
 					if (allNamespaces.contains(namespace.toLowerCase())) {
 						linkType = Link.type.UNKNOWN;
-				    }else{
+					}else{
 						linkType = Link.type.INTERNAL;
 					}
 					parameters = null;

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
@@ -147,15 +147,15 @@ public class ParserTest {
 
         ParsedPage pp = parser.parse(text);
 
-		List<String> uris = getUrisInParagraphs(pp);
-		assertThat(uris, hasItems("H2O:_Footprints_in_the_Sand", "Noriko_Hayami"));
+        List<String> uris = getUrisInParagraphs(pp);
+        assertThat(uris, hasItems("H2O:_Footprints_in_the_Sand", "Noriko_Hayami"));
 
-		// Making sure Links with ":" are considered Internals
-		Link h2OAnnotation = getLink(pp, "H2O:_Footprints_in_the_Sand");
-		assertEquals(h2OAnnotation.getType(), Link.type.INTERNAL);
-		assertEquals(getLink(pp, "Cite:AAA").getType(), Link.type.UNKNOWN);
+        // Making sure Links with ":" are considered Internals
+        Link h2OAnnotation = getLink(pp, "H2O:_Footprints_in_the_Sand");
+        assertEquals(h2OAnnotation.getType(), Link.type.INTERNAL);
+        assertEquals(getLink(pp, "Cite:AAA").getType(), Link.type.UNKNOWN);
 
-		testAnchorsInText(pp);
+        testAnchorsInText(pp);
     }
 
 

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/test/java/de/tudarmstadt/ukp/wikipedia/parser/ParserTest.java
@@ -4,9 +4,13 @@ import de.tudarmstadt.ukp.wikipedia.api.WikiConstants;
 import de.tudarmstadt.ukp.wikipedia.parser.mediawiki.MediaWikiParser;
 import de.tudarmstadt.ukp.wikipedia.parser.mediawiki.MediaWikiParserFactory;
 import org.junit.Test;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.matchers.JUnitMatchers.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Created by dav009 on 23/06/2015.
@@ -84,4 +88,76 @@ public class ParserTest {
         assert(testPar.getText().contains("a GP16, getting a new coat of paint at "));
 
     }
+
+	/*
+	* Matches the extracted anchors and spans against the text
+	* they have been extracted from.
+	* */
+	private void testAnchorsInText(ParsedPage page){
+
+		for (Section s : page.getSections()){
+			for (Paragraph p: s.getParagraphs()){
+				for (Link link : p.getLinks()) {
+					String anchorInPar = p.getText().substring(link.getPos().getStart(), link.getPos().getEnd());
+					assertEquals(anchorInPar, link.getText());
+				}
+			}
+		}
+	}
+
+	/*
+	* Get a list with all the annotated URIs
+	* */
+	public List<String> getUrisInParagraphs(ParsedPage page){
+		List<String> uris = new ArrayList<String>();
+		for (Section s : page.getSections()){
+			for (Paragraph p: s.getParagraphs()){
+				for (Link link : p.getLinks()) {
+					uris.add(link.getTarget());
+				}
+			}
+		}
+		return uris;
+	}
+
+	/*
+	* Get a list with all the annotated URIs
+	* */
+	public Link getLink(ParsedPage page, String uri){
+		for (Section s : page.getSections()){
+			for (Paragraph p: s.getParagraphs()){
+				for (Link link : p.getLinks()) {
+					if (uri.equals(link.getTarget()))
+						return link;
+				}
+			}
+		}
+		return null;
+	}
+
+    @Test
+    public void testExtractingLinksWithColons(){
+
+		// Regular paragraphs
+        String text ="'''Hayami''' Rena Hayami, [[Image:a.jgp]] images and file namespaces [[File:a.jpg]] " +
+				"''[[Category: Evolution]]'' [[Category:Jackson musical family]].\n \n Kohinata Hayami, " +
+				"[[H2O: Footprints in the Sand]] character. [[Cite:AAA]] [[Noriko Hayami]] (born 1959), Japanese actress.";
+        MediaWikiParserFactory pf = new MediaWikiParserFactory(WikiConstants.Language.english);
+        MediaWikiParser parser = pf.createParser();
+
+        ParsedPage pp = parser.parse(text);
+
+		List<String> uris = getUrisInParagraphs(pp);
+		assertThat(uris, hasItems("H2O:_Footprints_in_the_Sand", "Noriko_Hayami"));
+
+		// Making sure Links with ":" are considered Internals
+		Link h2OAnnotation = getLink(pp, "H2O:_Footprints_in_the_Sand");
+		assertEquals(h2OAnnotation.getType(), Link.type.INTERNAL);
+		assertEquals(getLink(pp, "Cite:AAA").getType(), Link.type.UNKNOWN);
+
+		testAnchorsInText(pp);
+    }
+
+
+
 }


### PR DESCRIPTION
Fixes: https://github.com/idio/json-wikipedia/issues/7
- There are DBpedia URIs and SFs which have `:` in them. i.e: `Star Wars: The Clone Wars`
- Currently annotations on those URIs get the `type.Unknown` because JWPL thinks that everything before `:` is a namespace (i.e: `Star Wars` in  `Star Wars: The Clone Wars` would be considered a namespace)
- Because those annotations get the `type.Unknown` jsonpedia does not output them as annotations

So this PR checks if the part before `:` is a namespace, if it is then considers the annotation `unknown` otherwise considers it `Internal`. This means we would get those annotations on jsonpedia.

Note: Got the set of namespaces from : (i) the wikipedia's wiki and (ii) by parsing one wikipedia dump and outputing annotations with `:`
